### PR TITLE
RLS: 0.7.0 + adopt conda-forge-linters suggestions

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,9 +1,9 @@
-{%set name = "pandas-datareader" %}
-{%set version = "0.7.0" %}
-{%set compress_type = "tar.gz" %}
-{%set hash_type = "sha256" %}
-{%set hash_val = "7dee3fe6fa483c8c2ee4f1af91a65b542c5446d75a6fc25c832cad1ffca8ef0b" %}
-{%set build_num = "0" %}
+{% set name = "pandas-datareader" %}
+{% set version = "0.7.0" %}
+{% set compress_type = "tar.gz" %}
+{% set hash_type = "sha256" %}
+{% set hash_val = "7dee3fe6fa483c8c2ee4f1af91a65b542c5446d75a6fc25c832cad1ffca8ef0b" %}
+{% set build_num = "0" %}
 
 package:
   name: {{ name|lower }}
@@ -15,14 +15,14 @@ source:
   {{ hash_type }}: {{ hash_val }}
 
 build:
+  noarch: python
   number: {{ build_num }}
-  script: python setup.py install --single-version-externally-managed --record=record.txt
-
+  script: "{{ PYTHON }} -m pip install . --no-deps -vv"
 
 requirements:
-  build:
+  host:
     - python
-    - setuptools
+    - pip
 
   run:
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,8 +1,8 @@
 {%set name = "pandas-datareader" %}
-{%set version = "0.6.0" %}
+{%set version = "0.7.0" %}
 {%set compress_type = "tar.gz" %}
 {%set hash_type = "sha256" %}
-{%set hash_val = "47681336a3f6e6953b024bd73f8bb005f36e8df831ccce336e9fc601c587e3db" %}
+{%set hash_val = "7dee3fe6fa483c8c2ee4f1af91a65b542c5446d75a6fc25c832cad1ffca8ef0b" %}
 {%set build_num = "0" %}
 
 package:
@@ -28,8 +28,6 @@ requirements:
     - python
     - pandas
     - requests >=2.3.0
-    - requests-file
-    - requests-ftp
 
 test:
   imports:
@@ -40,7 +38,7 @@ about:
   license: BSD-3
   license_file: LICENSE.md
   license_family: BSD
-  summary: 'Up to date remote data access for pandas, works for multiple versions of pandas'
+  summary: 'Extract data from a wide range of Internet sources into a pandas DataFrame.'
   dev_url: https://github.com/pydata/pandas-datareader
   doc_url: https://pandas-datareader.readthedocs.io/en/latest/
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,6 +28,8 @@ requirements:
     - python
     - pandas
     - requests >=2.3.0
+    - wrapt
+    - lxml
 
 test:
   imports:


### PR DESCRIPTION
This builds on top of #10 by @addisonlynch and adopts the conda-forge-linters suggestions:
* Add a space before set
* Use pip
* Make the package noarch
* Add wrapt and lxml to dependencies.